### PR TITLE
use the paths from torch exe to construct the luapath for both torch-pkg and luarocks.

### DIFF
--- a/interpreters/torch.lua
+++ b/interpreters/torch.lua
@@ -89,7 +89,7 @@ return {
       script = ('dofile [[%s]]'):format(filepath)
     end
     local code = ([[xpcall(function() io.stdout:setvbuf('no'); %s end,function(err) print(debug.traceback(err)) end)]]):format(script)
-    local cmd = '"'..torch..'"-e "'..code..'"'
+    local cmd = '"'..torch..'"-onethread -e "'..code..'"'
     -- CommandLineRun(cmd,wdir,tooutput,nohide,stringcallback,uid,endcallback)
     return CommandLineRun(cmd,self:fworkdir(wfilename),true,false,nil,nil,
       function() ide.debugger.pid = nil end)


### PR DESCRIPTION
Thanks for the port to torch, it is quite useful. I modified the interpreter a little so that the luapath and luacpath are constructed not from hard coded paths, but from the found torch executable. It should also work fine for both torch-pkg and luarocks installs. I hope I did not break anything. 
