### PR TITLE
Run as `./zbstudio.sh` instead of `sh zbstudio.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ luarocks install mobdebug
 ```bash
 $ git clone https://github.com/soumith/zbs-torch.git
 $ cd zbs-torch
-$ sh zbstudio.sh
+$ ./zbstudio.sh
 ```
 
 ## Usage
@@ -55,7 +55,7 @@ To debug a torch file,
 * Start zbs from the zbs-torch directory with the command
 
 ```bash
-$ sh zbstudio.sh
+$ ./zbstudio.sh
 ```
 * Start the debugger server from "Project->Start Debugger Server"
 


### PR DESCRIPTION
If I run `sh zbstudio.sh` in Bash I get:

    zbstudio.sh: 4: zbstudio.sh: Bad substitution
    zbstudio.sh: 6: zbstudio.sh: [[: not found

because zbstudio.sh uses Bash-specific features like `[[`.

Running it as `./zbstudio.sh` fixes this, since the shebang line is
obeyed.