### PR TITLE
Supporting commandline arguments under Torch 7

### DIFF
--- a/interpreters/torch.lua
+++ b/interpreters/torch.lua
@@ -67,9 +67,10 @@ return {
     
     -- local code = ([[xpcall(function() io.stdout:setvbuf('no'); %s end,function(err) print(debug.traceback(err)) end)]]):format(script)
     -- local cmd = '"'..torch..'" -e "'..code..'"'
-    local cmd = 'bash -c "cd $(dirname ' .. filepath .. ') && ' .. torch .. ' ' .. filepath .. ' "'
+    local params = ide.config.arg.any or ide.config.arg.lua
+    local cmd = 'bash -c "cd $(dirname ' .. filepath .. ') && ' .. torch .. ' ' .. filepath .. ' ' .. params .. '"'
     if ide.osname == "Windows" then
-      cmd = 'cmd /c "cd ' .. filepath .. '/../ && ' .. torch .. ' ' .. filepath .. ' "' 
+      cmd = 'cmd /c "cd ' .. filepath .. '/../ && ' .. torch .. ' ' .. filepath .. ' ' .. params .. '"'
     end
     -- CommandLineRun(cmd,wdir,tooutput,nohide,stringcallback,uid,endcallback)
     return CommandLineRun(cmd,self:fworkdir(wfilename),true,false,nil,nil,


### PR DESCRIPTION
When running or debugging torch code, the commandline arguments will be available now. 